### PR TITLE
safety checker: use empty class to save almost 1G of vram

### DIFF
--- a/services/generationserver.py
+++ b/services/generationserver.py
@@ -97,12 +97,12 @@ app = Flask(__name__,
             static_folder='../www')
 
 
-@ app.route('/')
+@app.route('/')
 def index():
     return redirect("/index.html", code=302)
 
 
-@ app.route("/generate/", methods=['POST'])
+@app.route("/generate/", methods=['POST'])
 def generate():
     args = request.get_json()
     return generate_bytes(args)


### PR DESCRIPTION
instead of initializing, then overriding, the safety checker, instead initialize it with an empty class. this saves on both loading time of the model and almost 1G of vram 