### PR TITLE
Add button to load params from JSON in clipboard

### DIFF
--- a/www/modules/panels/txt2img.js
+++ b/www/modules/panels/txt2img.js
@@ -55,6 +55,9 @@ export class TextToImage extends HTMLElement {
         <button id=hundredPresetButton>100</button>
       </details>
 
+      <button id=import>Import from clipboard</button>
+      <br>
+
       <button id=generateButton>Generate</button>
       <button id=nextButton>Next</button>
     `;
@@ -124,6 +127,16 @@ export class TextToImage extends HTMLElement {
 
     shadow.getElementById('promptbuilder').setEditor(
       shadow.getElementById('prompt'));
+
+    const importButton = shadow.getElementById('import');
+    importButton.addEventListener('click', async e => {
+      const text = await navigator.clipboard.readText();
+      try {
+        const json = JSON.parse(text);
+        this.setArgs(json);
+      } catch {
+      }
+    });
 
     this.shadow = shadow;
   }


### PR DESCRIPTION
Adds an "Import from clipboard" button. If the clipboard contains valid JSON, it will be applied as the prompt/parameters.

![image](https://user-images.githubusercontent.com/48894/189203639-785a4743-bfd3-4665-bf3e-64021213551d.png)
