### PR TITLE
Add save and load project support

### DIFF
--- a/www/modules/panels/appbar.js
+++ b/www/modules/panels/appbar.js
@@ -1,3 +1,6 @@
+import '../widgets/save-project-button.js';
+import '../widgets/open-project-button.js';
+
 export class AppBar extends HTMLElement {
   constructor() {
     super();
@@ -12,8 +15,16 @@ export class AppBar extends HTMLElement {
           position: relative;
           z-index: 10;
           box-shadow: 0px 0px 8px rgba(0, 0, 0, .5);
+          display: flex;
+          align-items: center;
         }
-        </style>
+        * {
+          margin: 5px;
+        }
+      </style>
+
+      <fs-save-project-button></fs-save-project-button>
+      <fs-open-project-button></fs-open-project-button>
     `;
     this.shadow = shadow;
   }

--- a/www/modules/panels/list.js
+++ b/www/modules/panels/list.js
@@ -1,4 +1,6 @@
 export class FsList extends HTMLElement {
+  history = [];
+
   constructor() {
     super();
     let shadow = this.attachShadow({mode: 'open'});
@@ -25,11 +27,12 @@ export class FsList extends HTMLElement {
         img.selected {
           box-shadow: 4px 4px 8px rgba(0, 0, 0, .75);
         }
-        </style>
+      </style>
     `;
     this.shadow = shadow;
   }
   addImage(uri, params) {
+    this.history.push({...params, uri});
     let img = new Image();
     img.src = uri;
     img.params = params;
@@ -48,6 +51,15 @@ export class FsList extends HTMLElement {
     this.shadow.prepend(img);
     if (shouldSelectNewImage) {
       this.select(img);
+    }
+  }
+  clearHistory() {
+    for (const item of this.history) {
+      URL.revokeObjectURL(item.uri);
+    }
+    this.history = [];
+    for (const img of this.shadow.querySelectorAll('img')) {
+      img.remove();
     }
   }
   select(img) {

--- a/www/modules/widgets/open-project-button.js
+++ b/www/modules/widgets/open-project-button.js
@@ -1,0 +1,42 @@
+export class LoadProjectButton extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({mode: 'open'});
+    shadow.innerHTML = `
+      <button>Open</button>
+    `;
+
+    const button = shadow.querySelector('button');
+    const list = document.querySelector('fs-list');
+    button.addEventListener('click', async () => {
+      const [fileHandle] = await window.showOpenFilePicker({
+        types: [
+          {
+            description: 'JSON files',
+            accept: {
+              'application/json': ['.json'],
+            },
+          },
+        ],
+      });
+      const file = await fileHandle.getFile();
+      const text = await file.text();
+      const project = JSON.parse(text);
+      list.clearHistory();
+      const converted = await Promise.all(
+        project.history.map(async (item) => {
+          const base64Url = item.uri;
+          const result = await fetch(base64Url);
+          const blob = await result.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          return {...item, uri: objectUrl};
+        })
+      );
+      for (const item of converted) {
+        list.addImage(item.uri, item);
+      }
+    });
+  }
+}
+
+window.customElements.define('fs-open-project-button', LoadProjectButton);

--- a/www/modules/widgets/save-project-button.js
+++ b/www/modules/widgets/save-project-button.js
@@ -23,7 +23,7 @@ export class SaveProjectButton extends HTMLElement {
           return {...item, uri: base64Url};
         })
       );
-      const project = {history};
+      const project = {version: 1, history};
       const blob = new Blob([JSON.stringify(project)], {
         type: "application/json",
       });

--- a/www/modules/widgets/save-project-button.js
+++ b/www/modules/widgets/save-project-button.js
@@ -1,0 +1,49 @@
+export class SaveProjectButton extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({mode: 'open'});
+    shadow.innerHTML = `
+      <button>Save</button>
+    `;
+
+    const button = shadow.querySelector("button");
+    const list = document.querySelector("fs-list");
+    button.addEventListener("click", async () => {
+      const history = await Promise.all(
+        list.history.map(async (item) => {
+          const objectUrl = item.uri;
+          const result = await fetch(objectUrl);
+          const blob = await result.blob();
+          const reader = new FileReader();
+          reader.readAsDataURL(blob);
+          await new Promise((resolve) => {
+            reader.addEventListener('loadend', resolve);
+          });
+          const base64Url = reader.result;
+          return {...item, uri: base64Url};
+        })
+      );
+      const project = {history};
+      const blob = new Blob([JSON.stringify(project)], {
+        type: "application/json",
+      });
+      const fileHandle = await window.showSaveFilePicker({
+        suggestedName: `${new Date().toISOString()}.json`,
+        types: [
+          {
+            description: "JSON files",
+            accept: {
+              "application/json": [".json"],
+            },
+          },
+        ],
+      });
+      const writable = await fileHandle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+    });
+
+  }
+}
+
+window.customElements.define('fs-save-project-button', SaveProjectButton);


### PR DESCRIPTION
Adds "Save" and "Load" buttons to the top bar, which write out the entire current project history to a JSON file using the browser file-system API. Images are base64 encoded.

<img src="https://user-images.githubusercontent.com/48894/189502166-7d9fdb37-c820-44d3-8fda-0773c5bea3ff.png" width="500px">
