### PR TITLE
Allows for queuing of prompts.

### DIFF
--- a/www/modules/panels/list.js
+++ b/www/modules/panels/list.js
@@ -31,14 +31,28 @@ export class FsList extends HTMLElement {
     `;
     this.shadow = shadow;
   }
-  addImage(uri, params) {
-    this.history.push({...params, uri});
+  queuePrompt(params) {
     let img = new Image();
-    img.src = uri;
     img.params = params;
+    img.title = "queued";
     img.addEventListener("click", e => {
-      this.select(img);
+      document.getElementById("detail").setImage(img.src);
+      document.getElementById("detail").setArgs(img.params);
     });
+    this.shadow.prepend(img);
+  }
+  getEarliestUnprocessedImageForProcessing() {
+    let images = this.shadow.querySelectorAll("img:not([src])");
+    if (images.length > 0) {
+      let image = images[images.length - 1];
+      image.title = 'processing ...';
+      return image;
+    }
+    return null;
+  }  
+  setImageSource(img, uri) {
+    this.history.push({...img.params, uri});
+    img.src = uri;
     img.addEventListener("dragstart", e => {
       e.dataTransfer.setData("text/plain", uri);
       e.dataTransfer.dropEffect = "copy";
@@ -48,7 +62,6 @@ export class FsList extends HTMLElement {
     // then select our new image. Otherwise leave the user's selection alone.
     const shouldSelectNewImage =
         !selected || selected == this.shadow.querySelector('img');
-    this.shadow.prepend(img);
     if (shouldSelectNewImage) {
       this.select(img);
     }


### PR DESCRIPTION
Instead of holding up the prompt editor from being used until the last dispatched prompt request is done, this change will queue the prompt in the history list for processing (not sure if history list is a proper name anymore). This allows for the next experiment to be off-loaded one's brain and entered in the prompt editor as soon as possible.